### PR TITLE
skip 22.12 until python SDK passes

### DIFF
--- a/.github/workflows/supported-versions.yml
+++ b/.github/workflows/supported-versions.yml
@@ -47,4 +47,4 @@ jobs:
       - name: Set Matrix
         id: set-matrix
         run: |
-          echo "::set-output name=matrix::[\"22_6\",\"22_8\",\"22_10\",\"22_12\"]"
+          echo "::set-output name=matrix::[\"22_6\",\"22_8\",\"22_10\"]"


### PR DESCRIPTION
Temporarily drop 22.12 from integration tests