### PR TITLE
Setup for marketplace viz repo ci and release workflows

### DIFF
--- a/.github/workflows/marketplace-viz-ci-build.yml
+++ b/.github/workflows/marketplace-viz-ci-build.yml
@@ -1,0 +1,20 @@
+name: viz-ci-build
+on: [workflow_call]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repo checkout
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          # Any higher and we need to update vizes to use webpack 5
+          node-version: '16'
+
+      - name: Install dependencies and build/bundle
+        run: |
+          yarn install --immutable --immutable-cache --check-cache
+          yarn build

--- a/.github/workflows/marketplace-viz-release.yml
+++ b/.github/workflows/marketplace-viz-release.yml
@@ -1,0 +1,47 @@
+name: viz-release
+on:
+  workflow_call:
+    secrets:
+      LOS_AUTO_BOT_RP_TOKEN:
+        required: true
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        id: release
+        with:
+          token: ${{ secrets.LOS_AUTO_BOT_RP_TOKEN }}
+          release-type: node
+
+  bundle-upload:
+    needs: release-please
+    runs-on: ubuntu-latest
+
+    if: ${{ needs.release-please.outputs.release_created }}
+    steps:
+      - name: Repo checkout
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          # Any higher and we need to update vizes to use webpack 5
+          node-version: '16'
+
+      - name: Install dependencies and build/bundle
+        run: |
+          yarn install --immutable --immutable-cache --check-cache
+          yarn build
+
+      - name: Upload/attach production dist to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ needs.release-please.outputs.tag_name }} dist/bundle.js
+          gh release upload ${{ needs.release-please.outputs.tag_name }} dist/bundle.js.map


### PR DESCRIPTION
Sets up reusable CI and release workflows for Marketplace Viz repos.

The release workflow requires the Looker Automation Bot token which must be set on each repo so that it can create release PRs and cut releases.  

These workflows have already been called successfully from a viz repo and work correctly. 
CI workflow : https://github.com/looker-open-source/viz-report-table-marketplace-open-source/actions/workflows/ci-build.yml
Release workflow: https://github.com/looker-open-source/viz-report-table-marketplace-open-source/actions/workflows/release.yml
 
The only thing untested is the bundle-upload job to attach the js to a release. This will be tested when we cut releases soon. Possible further PRs may be necessary. 