### PR TITLE
Update viz release workflow to not add bundle js source map

### DIFF
--- a/.github/workflows/marketplace-viz-release.yml
+++ b/.github/workflows/marketplace-viz-release.yml
@@ -44,4 +44,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ needs.release-please.outputs.tag_name }} dist/bundle.js
-          gh release upload ${{ needs.release-please.outputs.tag_name }} dist/bundle.js.map


### PR DESCRIPTION
We don't need the source map in the release. It can be manually generated if needed.