### PR TITLE
feat: Modernize viz-release reusable workflow to Node 20

### DIFF
--- a/.github/workflows/marketplace-viz-release.yml
+++ b/.github/workflows/marketplace-viz-release.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          # Any higher and we need to update vizes to use webpack 5
-          node-version: '16'
+          # Visualizations are modernized to use Webpack 5 and compile natively on Node 20
+          node-version: '20'
 
       - name: Install dependencies and build/bundle
         run: |


### PR DESCRIPTION
This PR updates the Node.js version in the reusable `marketplace-viz-release.yml` workflow from Node 16 to Node 20.

### Context
Since all 13 custom visualization repositories have been successfully modernized to Webpack 5 and compile natively on Node 20+, we can now safely upgrade the release workflow's Node runtime to Node 20 as well. This aligns the release pipeline with the CI build pipeline and eliminates the deprecated Node 16 runner usage.
